### PR TITLE
Homogenise LED theme setting + more precise typing

### DIFF
--- a/aioairq/__init__.py
+++ b/aioairq/__init__.py
@@ -9,10 +9,18 @@ __all__ = [
     "AirQ",
     "DeviceInfo",
     "NightMode",
+    "DeviceLedTheme",
+    "DeviceLedThemePatch",
     "InvalidAirQResponse",
     "InvalidAuth",
     "InvalidIpAddress",
 ]
 
-from aioairq.core import AirQ, DeviceInfo, NightMode
+from aioairq.core import (
+    AirQ,
+    DeviceInfo,
+    DeviceLedTheme,
+    DeviceLedThemePatch,
+    NightMode,
+)
 from aioairq.exceptions import InvalidAirQResponse, InvalidAuth, InvalidIpAddress

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -10,7 +10,25 @@ from aioairq.exceptions import InvalidAirQResponse, InvalidIpAddress
 from aioairq.utils import is_valid_ipv4_address
 
 LedThemeName = Literal[
-    "standard", "co2_covid19", "CO2", "VOC", "CO", "PM1", "PM2.5", "PM10", "Noise"
+    "standard",
+    "standard (contrast)",
+    "Virus",
+    "Virus (contrast)",
+    "co2_covid19",
+    "CO2",
+    "VOC",
+    "Humidity",
+    "CO",
+    "NO2",
+    "O3",
+    "Oxygen",
+    "PM1",
+    "PM2.5",
+    "PM10",
+    "Noise",
+    "Noise (contrast)",
+    "Noise Average",
+    "Noise Average (contrast)",
 ]
 
 


### PR DESCRIPTION
1. Use an explicit Literal type `LedThemeName` instead of `str` for the supported LED themes. Not very consequential.
2. Consider two different `TypedDict`s:
   - `DeviceLedTheme` which is expected to contain both `"left"` and `"right"` keys, and
   - `DeviceLedThemePatch` in which neither of the two keys is required With this logic in mind, a single `set_led_theme` may suffice to set the theme, given that the handling of the left or right themes is conceptually delegated to the initialisation of either of the two dictionaries.

---

@theHacker, can you have a look at this proposed change? I don't think I fully grasp the need for total 4 methods to set the LED themes, but I may have badly misunderstood your intentions.