### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "aioairq"
 readme = "README.md"
-license = { text = "Apache License, Version 2.0" }
+license = { text = "Apache-2.0" }
 dynamic = ["version"]
 description = "Asynchronous library to retrieve data from air-Q devices."
 authors = [


### PR DESCRIPTION
Use official SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/Apache-2.0.html