### PR TITLE
feat: historical data download via /dir, /file, /file_zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/aioairq.svg)](https://pypi.org/project/aioairq/0.3.0/)
 [![PyPI downloads](https://pepy.tech/badge/aioairq)](https://pypi.org/project/aioairq/0.3.0/)
+[![PyPI version](https://img.shields.io/pypi/v/aioairq)](https://pypi.org/project/aioairq/)
+[![license](https://img.shields.io/github/license/CorantGmbH/aioairq)](https://github.com/CorantGmbH/aioairq/blob/main/LICENSE)
+[![Tests](https://img.shields.io/github/actions/workflow/status/CorantGmbH/aioairq/tests.yml?label=Tests)](https://github.com/CorantGmbH/aioairq/actions)
 # PyPI package `aioairq`
 
 Python library for asynchronous data access to local air-Q devices.
@@ -27,6 +30,27 @@ async def main():
         print(f"Momentary data: {data}")
 
 asyncio.run(main())
+```
+
+## Download historical data
+
+The air-Q stores measurement data on its SD card. You can browse and download this data:
+
+```python
+async def main():
+    async with aiohttp.ClientSession() as session:
+        airq = AirQ(ADDRESS, PASSWORD, session)
+
+        # Browse the directory structure (year/month/day/timestamp)
+        years = await airq.get_historical_files_list()
+        days = await airq.get_historical_files_list("2024/5")
+        files = await airq.get_historical_files_list("2024/5/12")
+
+        # Download a file (compressed by default, ~1/5 the size)
+        data = await airq.get_historical_file("2024/5/12/1715000000")
+
+        # Or download uncompressed
+        data = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
 ```
 
 ## Logging

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ asyncio.run(main())
 The air-Q stores measurement data on its SD card. You can browse and download this data:
 
 ```python
+import asyncio
+import aiohttp
+from aioairq import AirQ
+
+ADDRESS = "123ab_air-q.local"
+PASSWORD = "airqsetup"
+
 async def main():
     async with aiohttp.ClientSession() as session:
         airq = AirQ(ADDRESS, PASSWORD, session)
@@ -51,6 +58,8 @@ async def main():
 
         # Or download uncompressed
         data = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+
+asyncio.run(main())
 ```
 
 ## Logging

--- a/aioairq/__init__.py
+++ b/aioairq/__init__.py
@@ -5,7 +5,7 @@ __credits__ = "Corant GmbH"
 __email__ = "daniel.lehmann@corant.de"
 __url__ = "https://www.air-q.com"
 __license__ = "Apache License 2.0"
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 __all__ = [
     "AirQ",
     "DeviceInfo",

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -525,8 +525,9 @@ class AirQ:
             Full file path, e.g. ``"2024/5/12/1715000000"``.
         compressed : bool
             If True (default), attempt ``/file_zlib`` first (~1/5 size) and
-            fall back to ``/file`` automatically if the compressed version is
-            not available (older firmware or file still open for writing).
+            fall back to ``/file`` if the response is not valid zlib data
+            (older firmware or file still open for writing).
+            Other errors (network, auth) are re-raised.
             If False, always use ``/file``.
 
         Returns
@@ -543,8 +544,8 @@ class AirQ:
                 decrypted = self.aes.decode_to_bytes(raw)
                 text = zlib.decompress(decrypted).decode("utf-8")
                 return [json.loads(line) for line in text.split("\n") if line]
-            except Exception:
-                pass  # fall back to /file below
+            except zlib.error:
+                pass  # /file_zlib not available for this path; fall back to /file
 
         encrypted_path = self.aes.encode(path)
         url = f"{self.anchor}/file?request={encrypted_path}"

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -344,6 +344,7 @@ class AirQ:
         async with self._session.get(
             f"{self.anchor}{relative_url}", timeout=self._timeout
         ) as response:
+            response.raise_for_status()
             return await response.text()
 
     async def _get_json(self, relative_url: str) -> dict:
@@ -550,6 +551,7 @@ class AirQ:
         compressed : bool
             If True (default), attempt ``/file_zlib`` first (~1/5 size) and
             fall back to ``/file`` if the response is not valid zlib data
+            or if ``/file_zlib`` responds with HTTP 404
             (older firmware or file still open for writing).
             Other errors (network, auth) are re-raised.
             If False, always use ``/file``.
@@ -561,11 +563,16 @@ class AirQ:
         """
         lines: list[str] = []  # only needed to silence pyright
         if compressed:
-            raw = await self._get_raw_file(path, route="file_zlib")
             try:
+                raw = await self._get_raw_file(path, route="file_zlib")
                 # /file_zlib returns a single encrypted blob of zlib-compressed data
                 decrypted = self.aes.decode_to_bytes(raw)
                 lines = zlib.decompress(decrypted).decode("utf-8").split("\n")
+            except aiohttp.ClientResponseError as e:
+                if e.status == 404:
+                    compressed = False  # fall back to /file
+                else:
+                    raise
             except zlib.error:
                 compressed = False  # fall back to /file
 

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -539,6 +539,45 @@ class AirQ:
 
         return entries
 
+    async def _fetch_compressed_lines(self, path: str) -> list[str] | None:
+        """Try fetching a historical file via ``/file_zlib``.
+
+        Returns the decompressed lines on success, or ``None`` if the
+        compressed version is unavailable (HTTP 404) or the payload is
+        not valid zlib data (e.g. the file is still being written to).
+        Other HTTP errors (network, auth) are re-raised.
+        """
+        try:
+            raw = await self._get_raw_file(path, route="file_zlib")
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                return None
+            raise
+
+        try:
+            decrypted = self.aes.decode_to_bytes(raw)
+            return zlib.decompress(decrypted).decode("utf-8").split("\n")
+        except zlib.error:
+            return None
+
+    async def _fetch_plain_lines(self, path: str) -> list[str]:
+        """Fetch a historical file via ``/file`` and split into lines."""
+        raw = await self._get_raw_file(path, route="file")
+        return raw.split("\n")
+
+    def _parse_historical_lines(self, lines: list[str]) -> list[dict]:
+        """Parse raw lines from a historical data file into measurement dicts.
+
+        Handles both plain-JSON and AES-encrypted line formats.
+        Empty lines are filtered out.
+        """
+        lines = [line for line in lines if line]
+        if not lines:
+            return []
+        if not lines[0].startswith("{"):
+            lines = [self.aes.decode(line) for line in lines]
+        return [json.loads(line) for line in lines]
+
     async def get_historical_file(
         self, path: str, *, compressed: bool = True
     ) -> list[dict]:
@@ -550,10 +589,7 @@ class AirQ:
             Full file path, e.g. ``"2024/5/12/1715000000"``.
         compressed : bool
             If True (default), attempt ``/file_zlib`` first (~1/5 size) and
-            fall back to ``/file`` if the response is not valid zlib data
-            or if ``/file_zlib`` responds with HTTP 404
-            (older firmware or file still open for writing).
-            Other errors (network, auth) are re-raised.
+            fall back to ``/file`` if the compressed version is unavailable.
             If False, always use ``/file``.
 
         Returns
@@ -561,33 +597,14 @@ class AirQ:
         list[dict]
             List of measurement dictionaries, each containing sensor readings.
         """
-        lines: list[str] = []  # only needed to silence pyright
+        lines = None
         if compressed:
-            try:
-                raw = await self._get_raw_file(path, route="file_zlib")
-                # /file_zlib returns a single encrypted blob of zlib-compressed data
-                decrypted = self.aes.decode_to_bytes(raw)
-                lines = zlib.decompress(decrypted).decode("utf-8").split("\n")
-            except aiohttp.ClientResponseError as e:
-                if e.status == 404:
-                    compressed = False  # fall back to /file
-                else:
-                    raise
-            except zlib.error:
-                compressed = False  # fall back to /file
+            lines = await self._fetch_compressed_lines(path)
 
-        if not compressed:
-            raw = await self._get_raw_file(path, route="file")
-            lines = raw.split("\n")
+        if lines is None:
+            lines = await self._fetch_plain_lines(path)
 
-        lines = [line for line in lines if line]
-        if not lines:
-            return []
-        # Lines are either unencrypted plain JSON or individually AES encrypted
-        if not lines[0].startswith("{"):
-            # yes an extra pass, but my benchmarks said it isn't prohibitive
-            lines = [self.aes.decode(line) for line in lines]
-        return [json.loads(line) for line in lines]
+        return self._parse_historical_lines(lines)
 
     async def get_possible_led_themes(self) -> List[LedThemeName]:
         return (await self._get_json_and_decode("/config"))["possibleLedTheme"]

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -124,7 +124,7 @@ class NightMode(TypedDict):
 
 
 class AirQ:
-    _supported_routes = ["config", "log", "data", "average", "ping"]
+    _json_envelope_routes = ["config", "log", "data", "average", "ping"]
 
     def __init__(
         self,
@@ -323,12 +323,13 @@ class AirQ:
     async def get(self, subject: str) -> dict:
         """Return the given subject from the air-Q device.
 
-        This function only works on a limited set of subject specified in _supported_routes.
-        Prefer using more specialized functions."""
-        if subject not in self._supported_routes:
+        This function only works on a limited set of subject specified in
+        _json_envelope_routes.
+        """
+        if subject not in self._json_envelope_routes:
             raise NotImplementedError(
                 "AirQ.get() is currently limited to a set of requests, returning "
-                f"a dict with a key 'content' (namely {self._supported_routes})."
+                f"a dict with a key 'content' (namely {self._json_envelope_routes})."
             )
 
         _LOGGER.debug("Fetching from %s", subject)

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -5,7 +5,7 @@ import logging
 import zlib
 import re
 from dataclasses import dataclass, field
-from typing import Any, List, Literal, TypedDict
+from typing import Any, List, Literal, TypedDict, get_args
 
 import aiohttp
 
@@ -20,6 +20,8 @@ from aioairq.utils import is_time_in_interval, is_valid_ipv4_address
 
 _LOGGER = logging.getLogger(__name__)
 
+
+_FileRoute = Literal["file", "file_zlib", "dir"]
 LedThemeName = Literal[
     "standard",
     "standard (contrast)",
@@ -332,16 +334,24 @@ class AirQ:
         _LOGGER.debug("Fetching from %s", subject)
         return await self._get_json_and_decode("/" + subject)
 
+    async def _get_raw(self, relative_url: str) -> str:
+        """GET ``relative_url`` and return the response body as text.
+
+        This is the lowest level method and the only one
+        which actually requests GET from the device.
+        """
+        async with self._session.get(
+            f"{self.anchor}{relative_url}", timeout=self._timeout
+        ) as response:
+            return await response.text()
+
     async def _get_json(self, relative_url: str) -> dict:
         """Executes a GET request to the air-Q device with the configured timeout
         and returns JSON data as a dictionary.
 
         relative_url is expected to start with a slash."""
 
-        async with self._session.get(
-            f"{self.anchor}{relative_url}", timeout=self._timeout
-        ) as response:
-            json_string = await response.text()
+        json_string = await self._get_raw(relative_url)
 
         try:
             return json.loads(json_string)
@@ -350,6 +360,23 @@ class AirQ:
                 "_get_json() must only be used to query endpoints returning JSON data. "
                 f"{relative_url} returned {json_string}."
             ) from e
+
+    async def _get_raw_file(self, path: str, route: _FileRoute = "file") -> str:
+        """Fetch raw response from a route that takes an encrypted path argument.
+
+        Parameters
+        ----------
+        path : str
+            Path on the device's SD card, e.g. ``"2024/5/12/1715000000"``.
+        route : ``"file"`` | ``"file_zlib"`` | ``"dir"``
+            Device route to query. The path is AES-encrypted and passed
+            via ``?request=``.
+        """
+        if route not in get_args(_FileRoute):
+            raise ValueError(f"Cannot query {path=} from {route=}")
+        encrypted_path = self.aes.encode(path)
+        relative_url = f"/{route}?request={encrypted_path}"
+        return await self._get_raw(relative_url)
 
     async def _get_json_and_decode(self, relative_url: str) -> Any:
         """Executes a GET request to the air-Q device with the configured timeout
@@ -497,11 +524,7 @@ class AirQ:
             - ``"2024/5"``: days in May 2024
             - ``"2024/5/12"``: file timestamps for that day
         """
-        encrypted_path = self.aes.encode(path)
-        url = f"{self.anchor}/dir?request={encrypted_path}"
-
-        async with self._session.get(url, timeout=self._timeout) as response:
-            raw = await response.text()
+        raw = await self._get_raw_file(path, route="dir")
 
         decoded = self.aes.decode(raw)
         entries: list[str] = json.loads(decoded)
@@ -535,30 +558,28 @@ class AirQ:
         list[dict]
             List of measurement dictionaries, each containing sensor readings.
         """
+        lines: list[str] = []  # only needed to silence pyright
         if compressed:
-            encrypted_path = self.aes.encode(path)
-            url = f"{self.anchor}/file_zlib?request={encrypted_path}"
-            async with self._session.get(url, timeout=self._timeout) as response:
-                raw = await response.text()
+            raw = await self._get_raw_file(path, route="file_zlib")
             try:
+                # /file_zlib returns a single encrypted blob of zlib-compressed data
                 decrypted = self.aes.decode_to_bytes(raw)
-                text = zlib.decompress(decrypted).decode("utf-8")
-                return [json.loads(line) for line in text.split("\n") if line]
+                lines = zlib.decompress(decrypted).decode("utf-8").split("\n")
             except zlib.error:
-                pass  # /file_zlib not available for this path; fall back to /file
+                compressed = False  # fall back to /file
 
-        encrypted_path = self.aes.encode(path)
-        url = f"{self.anchor}/file?request={encrypted_path}"
-        async with self._session.get(url, timeout=self._timeout) as response:
-            raw = await response.text()
-        lines = [line for line in raw.split("\n") if line]
+        if not compressed:
+            raw = await self._get_raw_file(path, route="file")
+            lines = raw.split("\n")
+
+        lines = [line for line in lines if line]
         if not lines:
             return []
-        # The device may store data encrypted or unencrypted on its SD card.
-        # Encrypted lines are base64-encoded; unencrypted lines are plain JSON.
-        if lines[0].startswith("{"):
-            return [json.loads(line) for line in lines]
-        return [json.loads(self.aes.decode(line)) for line in lines]
+        # Lines are either unencrypted plain JSON or individually AES encrypted
+        if not lines[0].startswith("{"):
+            # yes an extra pass, but my benchmarks said it isn't prohibitive
+            lines = [self.aes.decode(line) for line in lines]
+        return [json.loads(line) for line in lines]
 
     async def get_possible_led_themes(self) -> List[LedThemeName]:
         return (await self._get_json_and_decode("/config"))["possibleLedTheme"]

--- a/aioairq/core.py
+++ b/aioairq/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import zlib
 import re
 from dataclasses import dataclass, field
 from typing import Any, List, Literal, TypedDict
@@ -479,6 +480,84 @@ class AirQ:
 
     async def get_config(self) -> dict:
         return await self._get_json_and_decode("/config")
+
+    async def get_historical_files_list(self, path: str = "") -> list[str]:
+        """List entries in the device's historical data directory.
+
+        The air-Q stores data on its SD card in a year/month/day/timestamp
+        hierarchy.
+
+        Parameters
+        ----------
+        path : str
+            Directory path to list. Examples:
+
+            - ``""`` (empty): available years
+            - ``"2024"``: months in 2024
+            - ``"2024/5"``: days in May 2024
+            - ``"2024/5/12"``: file timestamps for that day
+        """
+        encrypted_path = self.aes.encode(path)
+        url = f"{self.anchor}/dir?request={encrypted_path}"
+
+        async with self._session.get(url, timeout=self._timeout) as response:
+            raw = await response.text()
+
+        decoded = self.aes.decode(raw)
+        entries: list[str] = json.loads(decoded)
+
+        # The root listing contains internal SD card directories (.zlib, .uncrypt,
+        # proc, logs, ...) alongside the actual year directories. Filter to only
+        # return plain numeric entries (years, months, days, or file timestamps).
+        if not path:
+            entries = [e for e in entries if e.isdigit()]
+
+        return entries
+
+    async def get_historical_file(
+        self, path: str, *, compressed: bool = True
+    ) -> list[dict]:
+        """Download a historical data file from the device.
+
+        Parameters
+        ----------
+        path : str
+            Full file path, e.g. ``"2024/5/12/1715000000"``.
+        compressed : bool
+            If True (default), attempt ``/file_zlib`` first (~1/5 size) and
+            fall back to ``/file`` automatically if the compressed version is
+            not available (older firmware or file still open for writing).
+            If False, always use ``/file``.
+
+        Returns
+        -------
+        list[dict]
+            List of measurement dictionaries, each containing sensor readings.
+        """
+        if compressed:
+            encrypted_path = self.aes.encode(path)
+            url = f"{self.anchor}/file_zlib?request={encrypted_path}"
+            async with self._session.get(url, timeout=self._timeout) as response:
+                raw = await response.text()
+            try:
+                decrypted = self.aes.decode_to_bytes(raw)
+                text = zlib.decompress(decrypted).decode("utf-8")
+                return [json.loads(line) for line in text.split("\n") if line]
+            except Exception:
+                pass  # fall back to /file below
+
+        encrypted_path = self.aes.encode(path)
+        url = f"{self.anchor}/file?request={encrypted_path}"
+        async with self._session.get(url, timeout=self._timeout) as response:
+            raw = await response.text()
+        lines = [line for line in raw.split("\n") if line]
+        if not lines:
+            return []
+        # The device may store data encrypted or unencrypted on its SD card.
+        # Encrypted lines are base64-encoded; unencrypted lines are plain JSON.
+        if lines[0].startswith("{"):
+            return [json.loads(line) for line in lines]
+        return [json.loads(self.aes.decode(line)) for line in lines]
 
     async def get_possible_led_themes(self) -> List[LedThemeName]:
         return (await self._get_json_and_decode("/config"))["possibleLedTheme"]

--- a/aioairq/encrypt.py
+++ b/aioairq/encrypt.py
@@ -43,19 +43,17 @@ class AESCipher:
         iv = decoded[: self._bs]
         cipher = AES.new(self._key, AES.MODE_CBC, iv)
         decrypted = cipher.decrypt(decoded[self._bs :])
-        return self._unpad_bytes(decrypted)
+        try:
+            return self._unpad_bytes(decrypted)
+        except ValueError as exc:
+            raise InvalidAuth("Failed to decrypt. Incorrect password?") from exc
 
     def decode(self, encrypted: str) -> str:
         unpadded = self.decode_to_bytes(encrypted)
         try:
-            # Currently the device does not support proper authentication.
-            # The success or failure of the authentication based on the ability
-            # to decode the response from the device.
             return unpadded.decode("utf-8")
-        except UnicodeDecodeError:
-            raise InvalidAuth(
-                "Failed to decode a message. Incorrect password"
-            ) from None
+        except UnicodeDecodeError as exc:
+            raise InvalidAuth("Failed to decrypt. Incorrect password?") from exc
 
     @staticmethod
     def _pad(data: bytes) -> bytes:
@@ -65,12 +63,12 @@ class AESCipher:
     @staticmethod
     def _unpad_bytes(data: bytes) -> bytes:
         if not data:
-            raise InvalidAuth("Failed to unpad: empty data")
+            raise ValueError("empty data")
         pad_len = data[-1]
         if pad_len < 1 or pad_len > AES.block_size:
-            raise InvalidAuth(f"Failed to unpad: invalid padding byte {pad_len!r}")
+            raise ValueError(f"invalid padding byte {pad_len!r}")
         if data[-pad_len:] != bytes([pad_len] * pad_len):
-            raise InvalidAuth("Failed to unpad: padding bytes are inconsistent")
+            raise ValueError("padding bytes are inconsistent")
         return data[:-pad_len]
 
     @staticmethod

--- a/aioairq/encrypt.py
+++ b/aioairq/encrypt.py
@@ -1,4 +1,5 @@
 """Module concerned with encryption of the data"""
+
 import base64
 
 from Crypto.Cipher import AES
@@ -26,11 +27,14 @@ class AESCipher:
         self._key = self._pass2aes(passw)
 
     def encode(self, data: str) -> str:
+        encoded = data.encode("utf-8")
+        return self.encode_bytes(encoded)
+
+    def encode_bytes(self, data: bytes) -> str:
         iv = Random.new().read(AES.block_size)
         cipher = AES.new(self._key, AES.MODE_CBC, iv)
 
-        encoded = data.encode("utf-8")
-        encrypted = iv + cipher.encrypt(self._pad(encoded))
+        encrypted = iv + cipher.encrypt(self._pad(data))
 
         return base64.b64encode(encrypted).decode("utf-8")
 

--- a/aioairq/encrypt.py
+++ b/aioairq/encrypt.py
@@ -72,7 +72,16 @@ class AESCipher:
 
     @staticmethod
     def _unpad_bytes(data: bytes) -> bytes:
-        return data[: -data[-1]]
+        if not data:
+            raise InvalidAuth("Failed to unpad: empty data")
+        pad_len = data[-1]
+        if pad_len < 1 or pad_len > AES.block_size:
+            raise InvalidAuth(
+                f"Failed to unpad: invalid padding byte {pad_len!r}"
+            )
+        if data[-pad_len:] != bytes([pad_len] * pad_len):
+            raise InvalidAuth("Failed to unpad: padding bytes are inconsistent")
+        return data[:-pad_len]
 
     @staticmethod
     def _pass2aes(passw: str) -> str:

--- a/aioairq/encrypt.py
+++ b/aioairq/encrypt.py
@@ -50,6 +50,17 @@ class AESCipher:
             ) from None
         return self._unpad(decoded)
 
+    def decode_to_bytes(self, encrypted: str) -> bytes:
+        """Decrypt and return raw bytes, without UTF-8 decoding.
+
+        Needed for payloads containing binary data (e.g. zlib-compressed).
+        """
+        decoded = base64.b64decode(encrypted)
+        iv = decoded[: self._bs]
+        cipher = AES.new(self._key, AES.MODE_CBC, iv)
+        decrypted = cipher.decrypt(decoded[self._bs :])
+        return self._unpad_bytes(decrypted)
+
     @staticmethod
     def _pad(data: bytes) -> bytes:
         length = 16 - (len(data) % 16)
@@ -58,6 +69,10 @@ class AESCipher:
     @staticmethod
     def _unpad(data: str) -> str:
         return data[: -ord(data[-1])]
+
+    @staticmethod
+    def _unpad_bytes(data: bytes) -> bytes:
+        return data[: -data[-1]]
 
     @staticmethod
     def _pass2aes(passw: str) -> str:

--- a/aioairq/encrypt.py
+++ b/aioairq/encrypt.py
@@ -34,22 +34,6 @@ class AESCipher:
 
         return base64.b64encode(encrypted).decode("utf-8")
 
-    def decode(self, encrypted: str) -> str:
-        decoded = base64.b64decode(encrypted)
-        iv = decoded[: self._bs]
-        cipher = AES.new(self._key, AES.MODE_CBC, iv)
-        decrypted = cipher.decrypt(decoded[self._bs :])
-        try:
-            # Currently the device does not support proper authentication.
-            # The success or failure of the authentication based on the ability
-            # to decode the response from the device.
-            decoded = decrypted.decode("utf-8")
-        except UnicodeDecodeError:
-            raise InvalidAuth(
-                "Failed to decode a message. Incorrect password"
-            ) from None
-        return self._unpad(decoded)
-
     def decode_to_bytes(self, encrypted: str) -> bytes:
         """Decrypt and return raw bytes, without UTF-8 decoding.
 
@@ -61,14 +45,22 @@ class AESCipher:
         decrypted = cipher.decrypt(decoded[self._bs :])
         return self._unpad_bytes(decrypted)
 
+    def decode(self, encrypted: str) -> str:
+        unpadded = self.decode_to_bytes(encrypted)
+        try:
+            # Currently the device does not support proper authentication.
+            # The success or failure of the authentication based on the ability
+            # to decode the response from the device.
+            return unpadded.decode("utf-8")
+        except UnicodeDecodeError:
+            raise InvalidAuth(
+                "Failed to decode a message. Incorrect password"
+            ) from None
+
     @staticmethod
     def _pad(data: bytes) -> bytes:
         length = 16 - (len(data) % 16)
         return data + bytes(chr(length) * length, "utf-8")
-
-    @staticmethod
-    def _unpad(data: str) -> str:
-        return data[: -ord(data[-1])]
 
     @staticmethod
     def _unpad_bytes(data: bytes) -> bytes:
@@ -76,9 +68,7 @@ class AESCipher:
             raise InvalidAuth("Failed to unpad: empty data")
         pad_len = data[-1]
         if pad_len < 1 or pad_len > AES.block_size:
-            raise InvalidAuth(
-                f"Failed to unpad: invalid padding byte {pad_len!r}"
-            )
+            raise InvalidAuth(f"Failed to unpad: invalid padding byte {pad_len!r}")
         if data[-pad_len:] != bytes([pad_len] * pad_len):
             raise InvalidAuth("Failed to unpad: padding bytes are inconsistent")
         return data[:-pad_len]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 [project.optional-dependencies]
-dev = ["ruff", "pre-commit", "pytest", "pytest-asyncio"]
+dev = ["ruff", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov"]
 
 
 [tool.setuptools.dynamic]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,10 @@ import os
 
 import pytest
 
-_AIRQ_IP_SET = bool(os.environ.get("AIRQ_IP"))
-
 
 def pytest_collection_modifyitems(session, config, items):
     """Skip all on-device tests when AIRQ_IP is not set."""
-    if _AIRQ_IP_SET:
+    if os.environ.get("AIRQ_IP"):
         return
     skip = pytest.mark.skip(reason="Set AIRQ_IP env var to run on-device tests")
     for item in items:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+_AIRQ_IP_SET = bool(os.environ.get("AIRQ_IP"))
+
+
+def pytest_collection_modifyitems(items):
+    """Skip all on-device tests when AIRQ_IP is not set."""
+    if _AIRQ_IP_SET:
+        return
+    skip = pytest.mark.skip(reason="Set AIRQ_IP env var to run on-device tests")
+    for item in items:
+        if item.fspath.basename == "test_core_on_device.py":
+            item.add_marker(skip)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 _AIRQ_IP_SET = bool(os.environ.get("AIRQ_IP"))
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(session, config, items):
     """Skip all on-device tests when AIRQ_IP is not set."""
     if _AIRQ_IP_SET:
         return

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -45,19 +45,19 @@ class TestUnpadBytes:
         assert AESCipher._unpad_bytes(padded) == payload
 
     def test_empty_data_raises(self):
-        with pytest.raises(InvalidAuth):
+        with pytest.raises(ValueError):
             AESCipher._unpad_bytes(b"")
 
     def test_zero_padding_byte_raises(self):
-        with pytest.raises(InvalidAuth):
+        with pytest.raises(ValueError):
             AESCipher._unpad_bytes(b"\x00" * 16)
 
     def test_padding_byte_too_large_raises(self):
-        with pytest.raises(InvalidAuth):
+        with pytest.raises(ValueError):
             AESCipher._unpad_bytes(bytes([17] * 17))
 
     def test_inconsistent_padding_raises(self):
         payload = b"hello"
         bad_padded = payload + b"\x03\x03\x02"
-        with pytest.raises(InvalidAuth):
+        with pytest.raises(ValueError):
             AESCipher._unpad_bytes(bad_padded)

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -25,3 +25,39 @@ def test_decrypt_failure():
 
     with pytest.raises(InvalidAuth):
         AESCipher("wrong-password").decode(encrypted)
+
+
+class TestUnpadBytes:
+    def test_valid_padding(self):
+        payload = b"hello\x00\x00\x00"
+        padded = payload + bytes([3] * 3)
+        assert AESCipher._unpad_bytes(padded) == payload
+
+    def test_full_block_padding(self):
+        payload = b"A" * 16
+        pad_len = 16
+        padded = payload + bytes([pad_len] * pad_len)
+        assert AESCipher._unpad_bytes(padded) == payload
+
+    def test_single_byte_padding(self):
+        payload = b"X" * 15
+        padded = payload + bytes([1])
+        assert AESCipher._unpad_bytes(padded) == payload
+
+    def test_empty_data_raises(self):
+        with pytest.raises(InvalidAuth):
+            AESCipher._unpad_bytes(b"")
+
+    def test_zero_padding_byte_raises(self):
+        with pytest.raises(InvalidAuth):
+            AESCipher._unpad_bytes(b"\x00" * 16)
+
+    def test_padding_byte_too_large_raises(self):
+        with pytest.raises(InvalidAuth):
+            AESCipher._unpad_bytes(bytes([17] * 17))
+
+    def test_inconsistent_padding_raises(self):
+        payload = b"hello"
+        bad_padded = payload + b"\x03\x03\x02"
+        with pytest.raises(InvalidAuth):
+            AESCipher._unpad_bytes(bad_padded)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -492,6 +492,17 @@ def _make_get_side_effect(responses: list[str]):
     return fake_get
 
 
+def _make_raw_file_by_route(route_to_response: dict[str, str]):
+    """Return a side_effect for ``_get_raw_file`` that dispatches by route."""
+
+    async def fake(path, route="file"):
+        if route in route_to_response:
+            return route_to_response[route]
+        raise AssertionError(f"Unexpected route: {route}")
+
+    return fake
+
+
 SAMPLE_RECORDS = [
     {"timestamp": 1715000000000, "co2": [604.0, 68.1], "Status": "OK"},
     {"timestamp": 1715000120000, "co2": [610.0, 70.0], "Status": "OK"},
@@ -595,16 +606,21 @@ async def test_get_historical_file_zlib(valid_address, passw, session):
 
 @pytest.mark.asyncio
 async def test_get_historical_file_zlib_fallback(valid_address, passw, session):
-    """If /file_zlib fails (e.g. not available), falls back to /file."""
+    """If /file_zlib returns non-zlib data, falls back to /file."""
     airq = AirQ(valid_address, passw, session)
 
-    # First response: garbage that will fail decompression → triggers fallback
-    bad_response = airq.aes.encode("this is not zlib data")
-    # Second response: valid plain-JSON /file response
-    good_response = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
+    bad_zlib = airq.aes.encode("this is not zlib data")
+    good_plain = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
 
     with patch.object(
-        session, "get", side_effect=_make_get_side_effect([bad_response, good_response])
+        airq,
+        "_get_raw_file",
+        side_effect=_make_raw_file_by_route(
+            {
+                "file_zlib": bad_zlib,
+                "file": good_plain,
+            }
+        ),
     ):
         result = await airq.get_historical_file("2024/5/12/1715000000", compressed=True)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,7 @@ import time
 import zlib
 from dataclasses import asdict
 from math import isclose
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
@@ -484,6 +484,7 @@ def _make_get_side_effect(responses: list[str]):
         text = next(it)
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value=text)
+        mock_response.raise_for_status = Mock()
         mock_cm = AsyncMock()
         mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
         mock_cm.__aexit__ = AsyncMock(return_value=False)
@@ -622,6 +623,30 @@ async def test_get_historical_file_zlib_fallback(valid_address, passw, session):
             }
         ),
     ):
+        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=True)
+
+    assert result == SAMPLE_RECORDS
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_zlib_404_fallback(valid_address, passw, session):
+    """/file_zlib 404 falls back to /file immediately."""
+    airq = AirQ(valid_address, passw, session)
+    good_plain = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
+
+    async def side_effect(path: str, route: str = "file"):
+        if route == "file_zlib":
+            raise aiohttp.ClientResponseError(
+                request_info=Mock(real_url=f"{airq.anchor}/file_zlib"),
+                history=(),
+                status=404,
+                message="Not Found",
+            )
+        if route == "file":
+            return good_plain
+        raise AssertionError(f"Unexpected route {route}")
+
+    with patch.object(airq, "_get_raw_file", side_effect=side_effect):
         result = await airq.get_historical_file("2024/5/12/1715000000", compressed=True)
 
     assert result == SAMPLE_RECORDS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import json
 import time
 import zlib
@@ -10,8 +9,6 @@ from unittest.mock import AsyncMock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
-from Crypto.Cipher import AES
-from Crypto import Random
 from pytest import approx, fixture
 
 from aioairq import AirQ
@@ -478,6 +475,7 @@ async def test_hanging_response_triggers_total_timeout(hanging_server, session):
 # Helpers for historical data tests
 # ---------------------------------------------------------------------------
 
+
 def _make_get_side_effect(responses: list[str]):
     """Return a side_effect function that feeds session.get() calls one by one."""
     it = iter(responses)
@@ -492,17 +490,6 @@ def _make_get_side_effect(responses: list[str]):
         return mock_cm
 
     return fake_get
-
-
-def _encrypt_bytes(passw: str, data: bytes) -> str:
-    """Encrypt raw bytes with the same AES-CBC scheme as AESCipher.encode."""
-    key = passw.encode("utf-8")
-    key = key + b"0" * (32 - len(key)) if len(key) < 32 else key[:32]
-    pad_len = 16 - (len(data) % 16)
-    padded = data + bytes([pad_len] * pad_len)
-    iv = Random.new().read(16)
-    cipher = AES.new(key, AES.MODE_CBC, iv)
-    return base64.b64encode(iv + cipher.encrypt(padded)).decode("utf-8")
 
 
 SAMPLE_RECORDS = [
@@ -522,10 +509,9 @@ async def test_historical_files_list_root_filters_non_numeric(
 ):
     """Root listing should only return numeric year entries."""
     airq = AirQ(valid_address, passw, session)
-    aes = AESCipher(passw)
 
     all_entries = ["2023", "2024", "2025", ".zlib", ".uncrypt", "logs", "proc", "csv"]
-    encrypted = aes.encode(json.dumps(all_entries))
+    encrypted = airq.aes.encode(json.dumps(all_entries))
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
         result = await airq.get_historical_files_list()
@@ -537,10 +523,9 @@ async def test_historical_files_list_root_filters_non_numeric(
 async def test_historical_files_list_subpath_returns_all(valid_address, passw, session):
     """Sub-path listings should be returned as-is."""
     airq = AirQ(valid_address, passw, session)
-    aes = AESCipher(passw)
 
     months = ["1", "2", "3", "12"]
-    encrypted = aes.encode(json.dumps(months))
+    encrypted = airq.aes.encode(json.dumps(months))
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
         result = await airq.get_historical_files_list("2024")
@@ -560,7 +545,9 @@ async def test_get_historical_file_plain_json(valid_address, passw, session):
     raw = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
-        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+        result = await airq.get_historical_file(
+            "2024/5/12/1715000000", compressed=False
+        )
 
     assert result == SAMPLE_RECORDS
 
@@ -569,11 +556,12 @@ async def test_get_historical_file_plain_json(valid_address, passw, session):
 async def test_get_historical_file_encrypted_lines(valid_address, passw, session):
     """Lines that are AES-encrypted (pre-encrypted storage) are decrypted."""
     airq = AirQ(valid_address, passw, session)
-    aes = AESCipher(passw)
-    raw = "\n".join(aes.encode(json.dumps(r)) for r in SAMPLE_RECORDS)
+    raw = "\n".join(airq.aes.encode(json.dumps(r)) for r in SAMPLE_RECORDS)
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
-        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+        result = await airq.get_historical_file(
+            "2024/5/12/1715000000", compressed=False
+        )
 
     assert result == SAMPLE_RECORDS
 
@@ -584,7 +572,9 @@ async def test_get_historical_file_empty(valid_address, passw, session):
     airq = AirQ(valid_address, passw, session)
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([""])):
-        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+        result = await airq.get_historical_file(
+            "2024/5/12/1715000000", compressed=False
+        )
 
     assert result == []
 
@@ -600,7 +590,7 @@ async def test_get_historical_file_zlib(valid_address, passw, session):
     airq = AirQ(valid_address, passw, session)
     text = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
     compressed = zlib.compress(text.encode("utf-8"))
-    encrypted = _encrypt_bytes(passw, compressed)
+    encrypted = airq.aes.encode_bytes(compressed)
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
         result = await airq.get_historical_file("2024/5/12/1715000000")
@@ -612,10 +602,9 @@ async def test_get_historical_file_zlib(valid_address, passw, session):
 async def test_get_historical_file_zlib_fallback(valid_address, passw, session):
     """If /file_zlib fails (e.g. not available), falls back to /file."""
     airq = AirQ(valid_address, passw, session)
-    aes = AESCipher(passw)
 
     # First response: garbage that will fail decompression → triggers fallback
-    bad_response = aes.encode("this is not zlib data")
+    bad_response = airq.aes.encode("this is not zlib data")
     # Second response: valid plain-JSON /file response
     good_response = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -539,17 +539,25 @@ async def test_historical_files_list_subpath_returns_all(valid_address, passw, s
 
 
 @pytest.mark.asyncio
-async def test_get_historical_file_plain_json(valid_address, passw, session):
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("\n".join(json.dumps(r) for r in SAMPLE_RECORDS), SAMPLE_RECORDS),
+        ("", []),  # empty file
+    ],
+)
+async def test_get_historical_file_plain_json(
+    valid_address, passw, session, raw, expected
+):
     """Lines that are already plain JSON (unencrypted storage) are parsed directly."""
     airq = AirQ(valid_address, passw, session)
-    raw = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
 
     with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
         result = await airq.get_historical_file(
             "2024/5/12/1715000000", compressed=False
         )
 
-    assert result == SAMPLE_RECORDS
+    assert result == expected
 
 
 @pytest.mark.asyncio
@@ -564,19 +572,6 @@ async def test_get_historical_file_encrypted_lines(valid_address, passw, session
         )
 
     assert result == SAMPLE_RECORDS
-
-
-@pytest.mark.asyncio
-async def test_get_historical_file_empty(valid_address, passw, session):
-    """An empty response returns an empty list."""
-    airq = AirQ(valid_address, passw, session)
-
-    with patch.object(session, "get", side_effect=_make_get_side_effect([""])):
-        result = await airq.get_historical_file(
-            "2024/5/12/1715000000", compressed=False
-        )
-
-    assert result == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@ import base64
 import json
 import time
 import zlib
-from contextlib import contextmanager
 from dataclasses import asdict
 from math import isclose
 from unittest.mock import AsyncMock, patch

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -546,107 +546,200 @@ async def test_historical_files_list_subpath_returns_all(valid_address, passw, s
 
 
 # ---------------------------------------------------------------------------
-# get_historical_file — /file endpoint (compressed=False)
+# _parse_historical_lines
+#
+# Pure method: no I/O, no mocking. Tested directly to cover line format
+# variations (plain JSON, AES-encrypted) and edge cases (empty input,
+# trailing blank lines) without routing through the full fetch pipeline.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "raw,expected",
+    "lines,expected",
     [
-        ("\n".join(json.dumps(r) for r in SAMPLE_RECORDS), SAMPLE_RECORDS),
-        ("", []),  # empty file
+        # plain JSON lines
+        (
+            [json.dumps(r) for r in SAMPLE_RECORDS],
+            SAMPLE_RECORDS,
+        ),
+        # empty input
+        ([], []),
+        # blank lines are filtered out
+        (
+            [json.dumps(SAMPLE_RECORDS[0]), "", "", json.dumps(SAMPLE_RECORDS[1]), ""],
+            SAMPLE_RECORDS,
+        ),
     ],
 )
-async def test_get_historical_file_plain_json(
-    valid_address, passw, session, raw, expected
+def test_parse_historical_lines_plain_json(
+    valid_address, passw, session, lines, expected
 ):
-    """Lines that are already plain JSON (unencrypted storage) are parsed directly."""
+    """Plain JSON lines (unencrypted storage) are parsed directly."""
     airq = AirQ(valid_address, passw, session)
-
-    with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
-        result = await airq.get_historical_file(
-            "2024/5/12/1715000000", compressed=False
-        )
-
-    assert result == expected
+    assert airq._parse_historical_lines(lines) == expected
 
 
-@pytest.mark.asyncio
-async def test_get_historical_file_encrypted_lines(valid_address, passw, session):
-    """Lines that are AES-encrypted (pre-encrypted storage) are decrypted."""
+def test_parse_historical_lines_encrypted(valid_address, passw, session):
+    """AES-encrypted lines are decrypted before JSON parsing."""
     airq = AirQ(valid_address, passw, session)
-    raw = "\n".join(airq.aes.encode(json.dumps(r)) for r in SAMPLE_RECORDS)
-
-    with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
-        result = await airq.get_historical_file(
-            "2024/5/12/1715000000", compressed=False
-        )
-
-    assert result == SAMPLE_RECORDS
+    encrypted_lines = [airq.aes.encode(json.dumps(r)) for r in SAMPLE_RECORDS]
+    assert airq._parse_historical_lines(encrypted_lines) == SAMPLE_RECORDS
 
 
 # ---------------------------------------------------------------------------
-# get_historical_file — /file_zlib endpoint (compressed=True, default)
+# _fetch_compressed_lines
+#
+# Tests the three possible outcomes of requesting /file_zlib:
+# success (returns lines), HTTP 404 (returns None to signal fallback),
+# invalid zlib payload (returns None). Non-404 HTTP errors must propagate.
+# Patching is done at _get_raw_file level — one layer above the network.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_historical_file_zlib(valid_address, passw, session):
-    """Compressed path: decrypts and decompresses the zlib blob."""
+async def test_fetch_compressed_lines_success(valid_address, passw, session):
+    """Happy path: /file_zlib returns a valid zlib blob."""
     airq = AirQ(valid_address, passw, session)
     text = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
     compressed = zlib.compress(text.encode("utf-8"))
     encrypted = airq.aes.encode_bytes(compressed)
 
-    with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
-        result = await airq.get_historical_file("2024/5/12/1715000000")
+    with patch.object(
+        airq,
+        "_get_raw_file",
+        side_effect=_make_raw_file_by_route({"file_zlib": encrypted}),
+    ):
+        lines = await airq._fetch_compressed_lines("2024/5/12/1715000000")
 
-    assert result == SAMPLE_RECORDS
+    assert lines is not None
+    assert airq._parse_historical_lines(lines) == SAMPLE_RECORDS
 
 
 @pytest.mark.asyncio
-async def test_get_historical_file_zlib_fallback(valid_address, passw, session):
-    """If /file_zlib returns non-zlib data, falls back to /file."""
+async def test_fetch_compressed_lines_404(valid_address, passw, session):
+    """HTTP 404 from /file_zlib returns None (signal to fall back)."""
     airq = AirQ(valid_address, passw, session)
 
+    async def raise_404(path, route="file"):
+        raise aiohttp.ClientResponseError(
+            request_info=Mock(real_url=f"{airq.anchor}/file_zlib"),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
+
+    with patch.object(airq, "_get_raw_file", side_effect=raise_404):
+        result = await airq._fetch_compressed_lines("2024/5/12/1715000000")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_compressed_lines_bad_zlib(valid_address, passw, session):
+    """Invalid zlib payload returns None (signal to fall back)."""
+    airq = AirQ(valid_address, passw, session)
     bad_zlib = airq.aes.encode("this is not zlib data")
-    good_plain = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
 
     with patch.object(
         airq,
         "_get_raw_file",
-        side_effect=_make_raw_file_by_route(
-            {
-                "file_zlib": bad_zlib,
-                "file": good_plain,
-            }
-        ),
+        side_effect=_make_raw_file_by_route({"file_zlib": bad_zlib}),
     ):
-        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=True)
+        result = await airq._fetch_compressed_lines("2024/5/12/1715000000")
 
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_compressed_lines_non_404_error_propagates(
+    valid_address, passw, session
+):
+    """Non-404 HTTP errors (e.g. 500) must not be swallowed."""
+    airq = AirQ(valid_address, passw, session)
+
+    async def raise_500(path, route="file"):
+        raise aiohttp.ClientResponseError(
+            request_info=Mock(real_url=f"{airq.anchor}/file_zlib"),
+            history=(),
+            status=500,
+            message="Internal Server Error",
+        )
+
+    with patch.object(airq, "_get_raw_file", side_effect=raise_500):
+        with pytest.raises(aiohttp.ClientResponseError, match="500"):
+            await airq._fetch_compressed_lines("2024/5/12/1715000000")
+
+
+# ---------------------------------------------------------------------------
+# get_historical_file (orchestrator)
+#
+# The orchestrator's job is call routing: try compressed, fall back to plain,
+# parse. The fallback logic itself is tested above in _fetch_compressed_lines.
+# Here we patch the private fetch methods to verify the orchestration contract
+# without duplicating zlib/HTTP concerns.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_uses_compressed_when_available(
+    valid_address, passw, session
+):
+    """compressed=True and compressed data available: only _fetch_compressed_lines is called."""
+    airq = AirQ(valid_address, passw, session)
+    sample_lines = [json.dumps(r) for r in SAMPLE_RECORDS]
+
+    with (
+        patch.object(
+            airq, "_fetch_compressed_lines", return_value=sample_lines
+        ) as mock_compressed,
+        patch.object(airq, "_fetch_plain_lines") as mock_plain,
+    ):
+        result = await airq.get_historical_file("2024/5/12/1715000000")
+
+    mock_compressed.assert_awaited_once_with("2024/5/12/1715000000")
+    mock_plain.assert_not_awaited()
     assert result == SAMPLE_RECORDS
 
 
 @pytest.mark.asyncio
-async def test_get_historical_file_zlib_404_fallback(valid_address, passw, session):
-    """/file_zlib 404 falls back to /file immediately."""
+async def test_get_historical_file_falls_back_to_plain(valid_address, passw, session):
+    """compressed=True but compressed unavailable: falls back to _fetch_plain_lines."""
     airq = AirQ(valid_address, passw, session)
-    good_plain = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
+    sample_lines = [json.dumps(r) for r in SAMPLE_RECORDS]
 
-    async def side_effect(path: str, route: str = "file"):
-        if route == "file_zlib":
-            raise aiohttp.ClientResponseError(
-                request_info=Mock(real_url=f"{airq.anchor}/file_zlib"),
-                history=(),
-                status=404,
-                message="Not Found",
-            )
-        if route == "file":
-            return good_plain
-        raise AssertionError(f"Unexpected route {route}")
+    with (
+        patch.object(
+            airq, "_fetch_compressed_lines", return_value=None
+        ) as mock_compressed,
+        patch.object(
+            airq, "_fetch_plain_lines", return_value=sample_lines
+        ) as mock_plain,
+    ):
+        result = await airq.get_historical_file("2024/5/12/1715000000")
 
-    with patch.object(airq, "_get_raw_file", side_effect=side_effect):
-        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=True)
+    mock_compressed.assert_awaited_once_with("2024/5/12/1715000000")
+    mock_plain.assert_awaited_once_with("2024/5/12/1715000000")
+    assert result == SAMPLE_RECORDS
 
+
+@pytest.mark.asyncio
+async def test_get_historical_file_skips_compressed_when_disabled(
+    valid_address, passw, session
+):
+    """compressed=False: skips _fetch_compressed_lines entirely."""
+    airq = AirQ(valid_address, passw, session)
+    sample_lines = [json.dumps(r) for r in SAMPLE_RECORDS]
+
+    with (
+        patch.object(airq, "_fetch_compressed_lines") as mock_compressed,
+        patch.object(
+            airq, "_fetch_plain_lines", return_value=sample_lines
+        ) as mock_plain,
+    ):
+        result = await airq.get_historical_file(
+            "2024/5/12/1715000000", compressed=False
+        )
+
+    mock_compressed.assert_not_awaited()
+    mock_plain.assert_awaited_once_with("2024/5/12/1715000000")
     assert result == SAMPLE_RECORDS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,9 @@
 import asyncio
+import base64
 import json
 import time
+import zlib
+from contextlib import contextmanager
 from dataclasses import asdict
 from math import isclose
 from unittest.mock import AsyncMock, patch
@@ -8,6 +11,8 @@ from unittest.mock import AsyncMock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
+from Crypto.Cipher import AES
+from Crypto import Random
 from pytest import approx, fixture
 
 from aioairq import AirQ
@@ -468,3 +473,156 @@ async def test_hanging_response_triggers_total_timeout(hanging_server, session):
     assert isclose(
         elapsed, timeout_expected, abs_tol=0.1, rel_tol=0.1
     ), f"Elapsed {elapsed:.3f}s suggests no read/total timeout was enforced"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for historical data tests
+# ---------------------------------------------------------------------------
+
+def _make_get_side_effect(responses: list[str]):
+    """Return a side_effect function that feeds session.get() calls one by one."""
+    it = iter(responses)
+
+    def fake_get(*args, **kwargs):
+        text = next(it)
+        mock_response = AsyncMock()
+        mock_response.text = AsyncMock(return_value=text)
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        return mock_cm
+
+    return fake_get
+
+
+def _encrypt_bytes(passw: str, data: bytes) -> str:
+    """Encrypt raw bytes with the same AES-CBC scheme as AESCipher.encode."""
+    key = passw.encode("utf-8")
+    key = key + b"0" * (32 - len(key)) if len(key) < 32 else key[:32]
+    pad_len = 16 - (len(data) % 16)
+    padded = data + bytes([pad_len] * pad_len)
+    iv = Random.new().read(16)
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    return base64.b64encode(iv + cipher.encrypt(padded)).decode("utf-8")
+
+
+SAMPLE_RECORDS = [
+    {"timestamp": 1715000000000, "co2": [604.0, 68.1], "Status": "OK"},
+    {"timestamp": 1715000120000, "co2": [610.0, 70.0], "Status": "OK"},
+]
+
+
+# ---------------------------------------------------------------------------
+# get_historical_files_list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_historical_files_list_root_filters_non_numeric(
+    valid_address, passw, session
+):
+    """Root listing should only return numeric year entries."""
+    airq = AirQ(valid_address, passw, session)
+    aes = AESCipher(passw)
+
+    all_entries = ["2023", "2024", "2025", ".zlib", ".uncrypt", "logs", "proc", "csv"]
+    encrypted = aes.encode(json.dumps(all_entries))
+
+    with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
+        result = await airq.get_historical_files_list()
+
+    assert result == ["2023", "2024", "2025"]
+
+
+@pytest.mark.asyncio
+async def test_historical_files_list_subpath_returns_all(valid_address, passw, session):
+    """Sub-path listings should be returned as-is."""
+    airq = AirQ(valid_address, passw, session)
+    aes = AESCipher(passw)
+
+    months = ["1", "2", "3", "12"]
+    encrypted = aes.encode(json.dumps(months))
+
+    with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
+        result = await airq.get_historical_files_list("2024")
+
+    assert result == months
+
+
+# ---------------------------------------------------------------------------
+# get_historical_file — /file endpoint (compressed=False)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_plain_json(valid_address, passw, session):
+    """Lines that are already plain JSON (unencrypted storage) are parsed directly."""
+    airq = AirQ(valid_address, passw, session)
+    raw = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
+
+    with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
+        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+
+    assert result == SAMPLE_RECORDS
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_encrypted_lines(valid_address, passw, session):
+    """Lines that are AES-encrypted (pre-encrypted storage) are decrypted."""
+    airq = AirQ(valid_address, passw, session)
+    aes = AESCipher(passw)
+    raw = "\n".join(aes.encode(json.dumps(r)) for r in SAMPLE_RECORDS)
+
+    with patch.object(session, "get", side_effect=_make_get_side_effect([raw])):
+        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+
+    assert result == SAMPLE_RECORDS
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_empty(valid_address, passw, session):
+    """An empty response returns an empty list."""
+    airq = AirQ(valid_address, passw, session)
+
+    with patch.object(session, "get", side_effect=_make_get_side_effect([""])):
+        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=False)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_historical_file — /file_zlib endpoint (compressed=True, default)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_zlib(valid_address, passw, session):
+    """Compressed path: decrypts and decompresses the zlib blob."""
+    airq = AirQ(valid_address, passw, session)
+    text = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
+    compressed = zlib.compress(text.encode("utf-8"))
+    encrypted = _encrypt_bytes(passw, compressed)
+
+    with patch.object(session, "get", side_effect=_make_get_side_effect([encrypted])):
+        result = await airq.get_historical_file("2024/5/12/1715000000")
+
+    assert result == SAMPLE_RECORDS
+
+
+@pytest.mark.asyncio
+async def test_get_historical_file_zlib_fallback(valid_address, passw, session):
+    """If /file_zlib fails (e.g. not available), falls back to /file."""
+    airq = AirQ(valid_address, passw, session)
+    aes = AESCipher(passw)
+
+    # First response: garbage that will fail decompression → triggers fallback
+    bad_response = aes.encode("this is not zlib data")
+    # Second response: valid plain-JSON /file response
+    good_response = "\n".join(json.dumps(r) for r in SAMPLE_RECORDS)
+
+    with patch.object(
+        session, "get", side_effect=_make_get_side_effect([bad_response, good_response])
+    ):
+        result = await airq.get_historical_file("2024/5/12/1715000000", compressed=True)
+
+    assert result == SAMPLE_RECORDS

--- a/tests/test_core_on_device.py
+++ b/tests/test_core_on_device.py
@@ -341,3 +341,75 @@ async def test_setting_brightness_config_wrongly(
         await airq_automatically_restoring_night_mode.set_brightness_config(
             **{target: value for target in targets}
         )
+
+
+@pytest.mark.asyncio
+async def test_historical_files_list(airq):
+    """Test browsing the historical data directory."""
+    years = await airq.get_historical_files_list()
+
+    assert isinstance(years, list)
+    assert len(years) > 0
+    assert all(isinstance(y, str) for y in years)
+
+    # Navigate one level deeper
+    months = await airq.get_historical_files_list(years[0])
+    assert isinstance(months, list)
+    assert len(months) > 0
+
+
+@pytest.mark.asyncio
+async def test_historical_file_download(airq):
+    """Test downloading a historical data file (uncompressed)."""
+    years = await airq.get_historical_files_list()
+    months = await airq.get_historical_files_list(years[-1])
+    days = await airq.get_historical_files_list(f"{years[-1]}/{months[-1]}")
+    files = await airq.get_historical_files_list(
+        f"{years[-1]}/{months[-1]}/{days[-1]}"
+    )
+
+    path = f"{years[-1]}/{months[-1]}/{days[-1]}/{files[0]}"
+    data = await airq.get_historical_file(path, compressed=False)
+
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert isinstance(data[0], dict)
+    assert "timestamp" in data[0]
+
+
+@pytest.mark.asyncio
+async def test_historical_file_download_compressed(airq):
+    """Test downloading a historical data file via /file_zlib with /file fallback."""
+    years = await airq.get_historical_files_list()
+
+    # Find a day with at least two files: the newest file on the device is
+    # still open for writing and therefore not yet compressed, so we need a
+    # non-latest file to exercise the /file_zlib path. If no such file exists
+    # (e.g. brand-new device), fall back to the single available file.
+    path = None
+    for year in reversed(years):
+        months = await airq.get_historical_files_list(year)
+        for month in reversed(months):
+            days = await airq.get_historical_files_list(f"{year}/{month}")
+            for day in reversed(days):
+                files = await airq.get_historical_files_list(
+                    f"{year}/{month}/{day}"
+                )
+                if len(files) > 1:
+                    path = f"{year}/{month}/{day}/{files[0]}"
+                    break
+            if path:
+                break
+        if path:
+            break
+
+    if path is None:
+        pytest.skip("No suitable historical file found (device too new?)")
+
+    # compressed=True: tries /file_zlib, falls back to /file automatically
+    data = await airq.get_historical_file(path, compressed=True)
+
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert isinstance(data[0], dict)
+    assert "timestamp" in data[0]

--- a/tests/test_core_on_device.py
+++ b/tests/test_core_on_device.py
@@ -377,3 +377,24 @@ async def test_historical_file_download(airq, compressed):
     assert len(data) > 0
     assert isinstance(data[0], dict)
     assert "timestamp" in data[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compressed", [False, True])
+async def test_historical_file_download_failing(airq, compressed):
+    """Test downloading a historical data file."""
+    # Use the oldest file on the device: it is guaranteed to be closed
+    # and fully compressed (if it isn't the only file),
+    # so to maximise the chanced of /file_zlib working properly.
+    years = await airq.get_historical_files_list()
+    months = await airq.get_historical_files_list(years[0])
+    days = await airq.get_historical_files_list(f"{years[0]}/{months[0]}")
+    files = await airq.get_historical_files_list(f"{years[0]}/{months[0]}/{days[0]}")
+
+    path = f"{years[0]}/{months[0]}/{days[0]}/{files[0]}"
+    data = await airq.get_historical_file(path, compressed=compressed)
+
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert isinstance(data[0], dict)
+    assert "timestamp" in data[0]

--- a/tests/test_core_on_device.py
+++ b/tests/test_core_on_device.py
@@ -377,24 +377,3 @@ async def test_historical_file_download(airq, compressed):
     assert len(data) > 0
     assert isinstance(data[0], dict)
     assert "timestamp" in data[0]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("compressed", [False, True])
-async def test_historical_file_download_failing(airq, compressed):
-    """Test downloading a historical data file."""
-    # Use the oldest file on the device: it is guaranteed to be closed
-    # and fully compressed (if it isn't the only file),
-    # so to maximise the chanced of /file_zlib working properly.
-    years = await airq.get_historical_files_list()
-    months = await airq.get_historical_files_list(years[0])
-    days = await airq.get_historical_files_list(f"{years[0]}/{months[0]}")
-    files = await airq.get_historical_files_list(f"{years[0]}/{months[0]}/{days[0]}")
-
-    path = f"{years[0]}/{months[0]}/{days[0]}/{files[0]}"
-    data = await airq.get_historical_file(path, compressed=compressed)
-
-    assert isinstance(data, list)
-    assert len(data) > 0
-    assert isinstance(data[0], dict)
-    assert "timestamp" in data[0]

--- a/tests/test_core_on_device.py
+++ b/tests/test_core_on_device.py
@@ -359,55 +359,19 @@ async def test_historical_files_list(airq):
 
 
 @pytest.mark.asyncio
-async def test_historical_file_download(airq):
-    """Test downloading a historical data file (uncompressed)."""
+@pytest.mark.parametrize("compressed", [False, True])
+async def test_historical_file_download(airq, compressed):
+    """Test downloading a historical data file."""
+    # Use the oldest file on the device: it is guaranteed to be closed
+    # and fully compressed (if it isn't the only file),
+    # so to maximise the chanced of /file_zlib working properly.
     years = await airq.get_historical_files_list()
     months = await airq.get_historical_files_list(years[-1])
     days = await airq.get_historical_files_list(f"{years[-1]}/{months[-1]}")
-    files = await airq.get_historical_files_list(
-        f"{years[-1]}/{months[-1]}/{days[-1]}"
-    )
+    files = await airq.get_historical_files_list(f"{years[-1]}/{months[-1]}/{days[-1]}")
 
     path = f"{years[-1]}/{months[-1]}/{days[-1]}/{files[0]}"
-    data = await airq.get_historical_file(path, compressed=False)
-
-    assert isinstance(data, list)
-    assert len(data) > 0
-    assert isinstance(data[0], dict)
-    assert "timestamp" in data[0]
-
-
-@pytest.mark.asyncio
-async def test_historical_file_download_compressed(airq):
-    """Test downloading a historical data file via /file_zlib with /file fallback."""
-    years = await airq.get_historical_files_list()
-
-    # Find a day with at least two files: the newest file on the device is
-    # still open for writing and therefore not yet compressed, so we need a
-    # non-latest file to exercise the /file_zlib path. If no such file exists
-    # (e.g. brand-new device), fall back to the single available file.
-    path = None
-    for year in reversed(years):
-        months = await airq.get_historical_files_list(year)
-        for month in reversed(months):
-            days = await airq.get_historical_files_list(f"{year}/{month}")
-            for day in reversed(days):
-                files = await airq.get_historical_files_list(
-                    f"{year}/{month}/{day}"
-                )
-                if len(files) > 1:
-                    path = f"{year}/{month}/{day}/{files[0]}"
-                    break
-            if path:
-                break
-        if path:
-            break
-
-    if path is None:
-        pytest.skip("No suitable historical file found (device too new?)")
-
-    # compressed=True: tries /file_zlib, falls back to /file automatically
-    data = await airq.get_historical_file(path, compressed=True)
+    data = await airq.get_historical_file(path, compressed=compressed)
 
     assert isinstance(data, list)
     assert len(data) > 0


### PR DESCRIPTION
## Summary

- Add `get_historical_files_list(path)` to browse the SD card directory structure (`year/month/day/timestamp` hierarchy); root listing filters out internal SD card directories (`.zlib`, `.uncrypt`, `logs`, etc.)
- Add `get_historical_file(path, compressed=True)` to download measurement files; tries `/file_zlib` first (~1/5 size) and falls back to `/file` automatically when the compressed version is not available (older firmware or file still open for writing)
- Add `decode_to_bytes` / `_unpad_bytes` to `AESCipher` for binary (zlib) payloads
- Add GitHub Actions CI workflow running pytest across Python 3.9–3.13
- Add README badges (PyPI version, license, Tests) and historical data usage example
- Add unit tests with mocks (no device required), including fallback behaviour
- Add on-device integration tests (skipped automatically when `AIRQ_IP` is not set)
- Add `conftest.py` to auto-skip on-device tests without env var

## Test plan

- [ ] `pytest tests/` passes locally without a device (on-device tests auto-skipped)
- [ ] `AIRQ_IP=<device> AIRQ_PASS=<pass> pytest tests/test_core_on_device.py -k historical` passes against a real device
- [ ] CI (GitHub Actions) passes on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)